### PR TITLE
Remove problem's sdg column

### DIFF
--- a/db/migrate/20201103155100_create_decidim_problems_problems.rb
+++ b/db/migrate/20201103155100_create_decidim_problems_problems.rb
@@ -9,7 +9,6 @@ class CreateDecidimProblemsProblems < ActiveRecord::Migration[5.2]
       t.references :decidim_challenges_challenge, index: { name: "decidim_challenges_challenges_problems" }, null: false
       t.references :decidim_scope, index: true
       t.jsonb :tags
-      t.references :sdg
       t.string :causes
       t.string :groups_affected
       t.integer :state, null: false, default: 0


### PR DESCRIPTION
### Purpose

Remove `Problem#sdg` column in problem migration because we'll obtain sdg through problem's challenge relation.

### :camera: Screenshots