### PR TITLE
Fix problems or solutions dropdown filter by participatory space

### DIFF
--- a/app/forms/decidim/problems/admin/problems_form.rb
+++ b/app/forms/decidim/problems/admin/problems_form.rb
@@ -49,7 +49,7 @@ module Decidim
         # Return a challenge's list filtered by participatory's space component
         def select_challenge_collection
           participatory_space = Decidim::Component.find(decidim_component_id).participatory_space
-          challenge_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: "challenges").first
+          challenge_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: "challenges")
           Decidim::Challenges::Challenge.where(component: challenge_component).map do |ch|
             [translated_attribute(ch.title), ch.id]
           end

--- a/app/forms/decidim/problems/admin/problems_form.rb
+++ b/app/forms/decidim/problems/admin/problems_form.rb
@@ -46,9 +46,11 @@ module Decidim
           end
         end
 
-        # Return a challenge's list
+        # Return a challenge's list filtered by participatory's space component
         def select_challenge_collection
-          Decidim::Challenges::Challenge.all.map do |ch|
+          participatory_space = Decidim::Component.find(decidim_component_id).participatory_space
+          challenge_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: 'challenges').first
+          Decidim::Challenges::Challenge.where(component: challenge_component).map do |ch|
             [translated_attribute(ch.title), ch.id]
           end
         end

--- a/app/forms/decidim/problems/admin/problems_form.rb
+++ b/app/forms/decidim/problems/admin/problems_form.rb
@@ -49,7 +49,7 @@ module Decidim
         # Return a challenge's list filtered by participatory's space component
         def select_challenge_collection
           participatory_space = Decidim::Component.find(decidim_component_id).participatory_space
-          challenge_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: 'challenges').first
+          challenge_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: "challenges").first
           Decidim::Challenges::Challenge.where(component: challenge_component).map do |ch|
             [translated_attribute(ch.title), ch.id]
           end

--- a/app/forms/decidim/solutions/admin/solutions_form.rb
+++ b/app/forms/decidim/solutions/admin/solutions_form.rb
@@ -32,7 +32,7 @@ module Decidim
         # Return a problem's list filtered by participatory's space component
         def select_problem_collection
           participatory_space = Decidim::Component.find(decidim_component_id).participatory_space
-          problem_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: "problems").first
+          problem_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: "problems")
           Decidim::Problems::Problem.where(component: problem_component).map do |p|
             [translated_attribute(p.title), p.id]
           end

--- a/app/forms/decidim/solutions/admin/solutions_form.rb
+++ b/app/forms/decidim/solutions/admin/solutions_form.rb
@@ -32,7 +32,7 @@ module Decidim
         # Return a problem's list filtered by participatory's space component
         def select_problem_collection
           participatory_space = Decidim::Component.find(decidim_component_id).participatory_space
-          problem_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: 'problems').first
+          problem_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: "problems").first
           Decidim::Problems::Problem.where(component: problem_component).map do |p|
             [translated_attribute(p.title), p.id]
           end

--- a/app/forms/decidim/solutions/admin/solutions_form.rb
+++ b/app/forms/decidim/solutions/admin/solutions_form.rb
@@ -29,9 +29,11 @@ module Decidim
 
         alias organization current_organization
 
-        # Return a problem's list
+        # Return a problem's list filtered by participatory's space component
         def select_problem_collection
-          Decidim::Problems::Problem.all.map do |p|
+          participatory_space = Decidim::Component.find(decidim_component_id).participatory_space
+          problem_component = Decidim::Component.where(participatory_space: participatory_space).where(manifest_name: 'problems').first
+          Decidim::Problems::Problem.where(component: problem_component).map do |p|
             [translated_attribute(p.title), p.id]
           end
         end

--- a/app/views/decidim/problems/admin/problems/index.html.erb
+++ b/app/views/decidim/problems/admin/problems/index.html.erb
@@ -24,6 +24,9 @@
               <%= t("models.problem.fields.created_at", scope: "decidim.problems.admin") %>
             </th>
             <th>
+              <%= t("models.problem.fields.challenge", scope: "decidim.problems.admin") %>
+            </th>
+            <th>
               <%= t("models.problem.fields.state", scope: "decidim.problems.admin") %>
             </th>
             <th>
@@ -46,6 +49,9 @@
               </td>
               <td class="table-list__state">
                 <%= l(problem.created_at, format: :decidim_short) if problem.created_at %>
+              </td>
+              <td class="table-list__state">
+                <%= translated_attribute(problem.challenge.title) %>
               </td>
               <td class="table-list__state">
                 <%= I18n.t(problem.state, scope: "decidim.problems.states") %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -962,6 +962,7 @@ ca:
             fields:
               challenge: Repte
               created_at: Creat
+              challenge: Repte
               end_date: Data fi
               published: Publicat
               start_date: Data inici

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -967,6 +967,7 @@ en:
             fields:
               challenge: Challenge
               created_at: Created at
+              challenge: Challenge
               end_date: End date
               published: Published
               start_date: Start date

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -970,6 +970,7 @@ es:
             fields:
               challenge: Reto
               created_at: Creado
+              challenge: Reto
               end_date: Fecha fin
               published: Publicado
               start_date: Fecha inicio


### PR DESCRIPTION
### Purpose

This fixes that when creating a problem or solution, the dropdown isn't filtering by participatory space.
So, when creating a problem, the challenges dropdown shows all Challenges instead filtering them by parent Participatory Space. Same occurs with solution's problems dropdown.
