### PR TITLE
Do not allow access to manage SDGs components

### DIFF
--- a/app/controllers/decidim/sdgs/admin/application_controller.rb
+++ b/app/controllers/decidim/sdgs/admin/application_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Sdgs
+    module Admin
+      # This controller is the abstract class from which all other controllers of
+      # this engine inherit.
+      #
+      # Note that it inherits from `Decidim::Admin::Components::BaseController`, which
+      # override its layout and provide all kinds of useful methods.
+      class ApplicationController < Decidim::Admin::Components::BaseController
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/sdgs/admin/sdgs_controller.rb
+++ b/app/controllers/decidim/sdgs/admin/sdgs_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Sdgs
+    module Admin
+      # Controller that allows managing admin Sdgs.
+      #
+      class SdgsController < Decidim::Sdgs::Admin::ApplicationController
+        include Decidim::ApplicationHelper
+
+        def index
+          flash[:alert] = t(".cant_manage")
+          redirect_to decidim_admin_participatory_processes.components_path(current_participatory_space)
+        end
+      end
+    end
+  end
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1047,6 +1047,10 @@ ca:
         proposal: Proposada
       challenge: Repte
     sdgs:
+      admin:
+        sdgs:
+          index:
+            cant_manage: Els ODSs no es poden gestionar. No hi ha res per configurar.
       names:
         clean_energy: Energia neta i assequible
         clean_water: Aigua neta i sanejament

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1052,6 +1052,10 @@ en:
         proposal: Proposal
       challenge: Challenge
     sdgs:
+      admin:
+        sdgs:
+          index:
+            cant_manage: SDGs can't be managed. Nothing to configure.
       names:
         clean_energy: Clean energy
         clean_water: Clean water

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1056,6 +1056,10 @@ es:
         proposal: Propuesta
       challenge: Reto
     sdgs:
+      admin:
+        sdgs:
+          index:
+            cant_manage: Los ODSs no se pueden gestionar. Nada por configurar.
       names:
         clean_energy: Energia limpia y asequible
         clean_water: Agua limpia y saneada

--- a/lib/decidim/sdgs/admin_engine.rb
+++ b/lib/decidim/sdgs/admin_engine.rb
@@ -11,7 +11,8 @@ module Decidim
 
       routes do
         # Add admin engine routes here
-        # resources :challenges do
+        resources :sdgs, only: :index
+        # resources :sdgs do
         #   collection do
         #     resources :exports, only: [:create]
         #   end

--- a/spec/system/decidim/problems/admin/manage_problems_spec.rb
+++ b/spec/system/decidim/problems/admin/manage_problems_spec.rb
@@ -7,7 +7,6 @@ describe "Admin creates problems", type: :system do
   let(:organization) { participatory_process.organization }
   let!(:user) { create :user, :admin, :confirmed, organization: organization }
   let!(:problem) { create :problem, component: component }
-  let(:creation_enabled?) { true }
 
   include_context "when managing a component as an admin"
 

--- a/spec/system/decidim/sdgs/admin/manage_sdgs_spec.rb
+++ b/spec/system/decidim/sdgs/admin/manage_sdgs_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin accesses SDGs", type: :system do
+  let(:manifest_name) { "sdgs" }
+  let(:organization) { participatory_process.organization }
+  let!(:user) { create :user, :admin, :confirmed, organization: organization }
+  let(:components_path) { decidim_admin_participatory_processes.components_path(participatory_process) }
+
+  include_context "when managing a component as an admin"
+
+  describe "accessing sdgs" do
+    it "redirects back to space components list" do
+      visit_component_admin
+
+      expect(page).to have_current_path components_path
+      have_admin_callout("SDGs can't be managed. Nothing to configure")
+    end
+  end
+end

--- a/spec/system/decidim/solutions/admin/manage_solutions_spec.rb
+++ b/spec/system/decidim/solutions/admin/manage_solutions_spec.rb
@@ -7,7 +7,6 @@ describe "Admin creates solutions", type: :system do
   let(:organization) { participatory_process.organization }
   let!(:user) { create :user, :admin, :confirmed, organization: organization }
   let!(:solution) { create :solution, component: component }
-  let(:creation_enabled?) { true }
 
   include_context "when managing a component as an admin"
 


### PR DESCRIPTION
Because there's nothing to configure or manage.