### PR TITLE
Longer titles for main models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.0.6 (MINOR)
+- Make titles longer
+
 ## Version 0.0.5 (PATCH)
 - Fix solution detail don't render SDG when the parent is a Challenge.
 - Increase Rspec suite timeout to 15 minutes.

--- a/app/forms/decidim/challenges/admin/challenges_form.rb
+++ b/app/forms/decidim/challenges/admin/challenges_form.rb
@@ -12,7 +12,7 @@ module Decidim
         mimic :challenge
 
         translatable_attribute :title, String do |field, _locale|
-          validates field, length: { in: 5..50 }, if: proc { |resource| resource.send(field).present? }
+          validates field, length: { in: 5..150 }, if: proc { |resource| resource.send(field).present? }
         end
         translatable_attribute :local_description, String
         translatable_attribute :global_description, String

--- a/app/forms/decidim/problems/admin/problems_form.rb
+++ b/app/forms/decidim/problems/admin/problems_form.rb
@@ -11,7 +11,7 @@ module Decidim
         mimic :problem
 
         translatable_attribute :title, String do |field, _locale|
-          validates field, length: { in: 5..50 }, if: proc { |resource| resource.send(field).present? }
+          validates field, length: { in: 5..150 }, if: proc { |resource| resource.send(field).present? }
         end
         translatable_attribute :description, String
 

--- a/app/forms/decidim/solutions/admin/solutions_form.rb
+++ b/app/forms/decidim/solutions/admin/solutions_form.rb
@@ -11,7 +11,7 @@ module Decidim
         mimic :solution
 
         translatable_attribute :title, String do |field, _locale|
-          validates field, length: { in: 5..50 }, if: proc { |resource| resource.send(field).present? }
+          validates field, length: { in: 5..150 }, if: proc { |resource| resource.send(field).present? }
         end
         translatable_attribute :description, String
 

--- a/lib/decidim/challenges/version.rb
+++ b/lib/decidim/challenges/version.rb
@@ -4,7 +4,7 @@ module Decidim
   # This holds the decidim-meetings version.
   module Challenges
     def self.version
-      "0.0.5"
+      "0.0.6"
     end
 
     def self.decidim_version


### PR DESCRIPTION
I2cat requested longer titles for the main entities.

Title limit has been setted to 150 chars, like in proposals.