### PR TITLE
Truncate description in cards to 100 chars max

### DIFF
--- a/app/cells/decidim/challenges/challenge_m_cell.rb
+++ b/app/cells/decidim/challenges/challenge_m_cell.rb
@@ -16,7 +16,8 @@ module Decidim
       end
 
       def description
-        translated_attribute model.global_description
+        text= translated_attribute(model.global_description)
+        decidim_sanitize(html_truncate(text, length: 100))
       end
 
       def challenge_path

--- a/app/cells/decidim/challenges/challenge_m_cell.rb
+++ b/app/cells/decidim/challenges/challenge_m_cell.rb
@@ -16,7 +16,7 @@ module Decidim
       end
 
       def description
-        text= translated_attribute(model.global_description)
+        text = translated_attribute(model.global_description)
         decidim_sanitize(html_truncate(text, length: 100))
       end
 

--- a/app/cells/decidim/problems/problem_m_cell.rb
+++ b/app/cells/decidim/problems/problem_m_cell.rb
@@ -30,7 +30,7 @@ module Decidim
       end
 
       def resource_description
-        text= translated_attribute(model.description)
+        text = translated_attribute(model.description)
         decidim_sanitize(html_truncate(text, length: 100))
       end
 

--- a/app/cells/decidim/problems/problem_m_cell.rb
+++ b/app/cells/decidim/problems/problem_m_cell.rb
@@ -30,7 +30,8 @@ module Decidim
       end
 
       def resource_description
-        translated_attribute model.description
+        text= translated_attribute(model.description)
+        decidim_sanitize(html_truncate(text, length: 100))
       end
 
       def resource_state

--- a/app/cells/decidim/solutions/solution_m_cell.rb
+++ b/app/cells/decidim/solutions/solution_m_cell.rb
@@ -27,7 +27,7 @@ module Decidim
       end
 
       def description
-        text= translated_attribute(model.description)
+        text = translated_attribute(model.description)
         decidim_sanitize(html_truncate(text, length: 100))
       end
 

--- a/app/cells/decidim/solutions/solution_m_cell.rb
+++ b/app/cells/decidim/solutions/solution_m_cell.rb
@@ -27,7 +27,8 @@ module Decidim
       end
 
       def description
-        translated_attribute model.description
+        text= translated_attribute(model.description)
+        decidim_sanitize(html_truncate(text, length: 100))
       end
 
       def solution_path


### PR DESCRIPTION
Resources with long descriptions produce cards that are to long, only having a couple of long cards will make the list of cars unusable.

![imatge](https://user-images.githubusercontent.com/199462/129888636-e98be92f-121a-45c7-b74f-4cbdcfa71e2f.png)

This PR truncates the `description` part of the cards of challenges, problems and solutions to a maximum of 100 characters. Like in Proposals.

