### PR TITLE
Fix: show solutions only when everything is published

### DIFF
--- a/.rubocop_rails.yml
+++ b/.rubocop_rails.yml
@@ -77,7 +77,7 @@ Rails/ScopeArgs:
     - decidim-*/app/models/**/*.rb
 
 Rails/SkipsModelValidations:
-  Enabled: true
+  Enabled: false
 
 Rails/Validation:
   Include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Following Semantic Versioning 2.
 ## next version:
 
 ## Version 0.0.7 (MINOR)
+- Fix: show solutions only when everything is published
 - Truncate description in cards to 100 chars max
 
 ## Version 0.0.6 (MINOR)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-challenges (0.0.6)
+    decidim-challenges (0.0.7)
       decidim-core (~> 0.24.2)
 
 GEM

--- a/app/helpers/decidim/challenges/challenges_helper.rb
+++ b/app/helpers/decidim/challenges/challenges_helper.rb
@@ -15,6 +15,18 @@ module Decidim
           ]
         )
       end
+
+      def challenge_associated_solutions(challenge)
+        solutions_component = Decidim::Component.find_by(participatory_space: challenge.participatory_space, manifest_name: "solutions")
+        return [] unless solutions_component&.published?
+
+        problems_component = Decidim::Component.find_by(participatory_space: challenge.participatory_space, manifest_name: "problems")
+        if problems_component&.published?
+          challenge.problems.published.map { |problem| problem.solutions.published }.flatten
+        else
+          challenge.solutions.published
+        end
+      end
     end
   end
 end

--- a/app/views/decidim/challenges/challenges/show.html.erb
+++ b/app/views/decidim/challenges/challenges/show.html.erb
@@ -1,16 +1,6 @@
 <%= stylesheet_link_tag "decidim/sdgs/ods" %>
 <%= stylesheet_link_tag "decidim/challenges/challenges" %>
 
-<% associated_solutions_list = [] %>
-<% if @challenge.problems.present? %>
-  <% @challenge.problems.each do |problem| %>
-    <% associated_solutions_list.concat problem.solutions %>
-  <% end %>
-<% else %>
-  <% @challenge.solutions.each do |solution| %>
-    <% associated_solutions_list << solution %>
-  <% end %>
-<% end %>
 <div class="row column">
   <div class="row">
 
@@ -111,7 +101,7 @@
 
         <h3><strong><%= t("proposed_solutions", scope: "decidim.challenges.show") %></strong></h3>
         <div class="row small-up-1 medium-up-2 card-grid">
-          <% associated_solutions_list.each do |solution| %>
+          <% challenge_associated_solutions(@challenge).each do |solution| %>
             <div class="column">
               <div class="card card-proposed-solution">
                 <%= link_to resource_locator(solution).path, class: "card__link" do %>

--- a/spec/cells/decidim/solutions/solution_m_cell_spec.rb
+++ b/spec/cells/decidim/solutions/solution_m_cell_spec.rb
@@ -20,9 +20,7 @@ module Decidim::Solutions
 
     shared_examples "rendering the cell" do
       before do
-        # rubocop: disable Rails/SkipsModelValidations
         challenge.update_columns(sdg_code: sdg_code)
-        # rubocop: enable Rails/SkipsModelValidations
       end
 
       it "renders the card" do

--- a/spec/helpers/decidim/challenges/challenges_helper_spec.rb
+++ b/spec/helpers/decidim/challenges/challenges_helper_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Challenges
+  describe ChallengesHelper do
+    subject { helper.challenge_associated_solutions(challenge) }
+
+    let(:challenge) { create(:challenge) }
+    let(:participatory_space) { challenge.participatory_space }
+    let(:solutions_component) { create(:solutions_component, participatory_space: challenge.participatory_space) }
+
+    context "when solutions are associated to problems" do
+      let(:problems_component) { create(:problems_component, participatory_space: challenge.participatory_space) }
+      let(:problem) { create :problem, component: problems_component, challenge: challenge }
+      let!(:solution) { create(:solution, component: solutions_component, problem: problem) }
+
+      it "shows solutions if the problem is published" do
+        expect(subject).to include(solution)
+      end
+
+      # rubocop: disable RSpec/RepeatedExample
+      it "hides solutions if the problem is published but the solutions are NOT published" do
+        solution.update_attribute(:published_at, nil)
+        expect(subject).to be_empty
+      end
+
+      it "hides solutions if the solutions component is NOT published" do
+        solutions_component.update_attribute(:published_at, nil)
+        expect(subject).to be_empty
+      end
+
+      it "hides solutions if the problems component is NOT published" do
+        solution.update_attribute(:published_at, nil)
+        expect(subject).to be_empty
+      end
+      # rubocop: enable RSpec/RepeatedExample
+
+      it "hides solutions if the problem is NOT published" do
+        problem.update_attribute(:published_at, nil)
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when solutions are associated to challenges" do
+      let!(:solution) { create(:solution, component: solutions_component, challenge: challenge) }
+
+      it "shows solutions if challenge is published" do
+        expect(subject).to include(solution)
+      end
+
+      it "hides solutions if the solutions component is NOT published" do
+        solutions_component.update_attribute(:published_at, nil)
+        expect(subject).to be_empty
+      end
+
+      it "hides solutions NOT published" do
+        solution.update_attribute(:published_at, nil)
+        expect(subject).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Solutions are always being rendered, despite the state of the components and the resources.
This PR solves this situation by controlling related components and resources.