### PR TITLE
Fix survey preview with answers

### DIFF
--- a/app/commands/decidim/challenges/survey_challenge.rb
+++ b/app/commands/decidim/challenges/survey_challenge.rb
@@ -10,7 +10,6 @@ module Decidim
       # user - The user answering the survey.
       # survey_form - A form object with params; can be a questionnaire.
       def initialize(challenge, user, survey_form)
-        super()
         @challenge = challenge
         @user = user
         @survey_form = survey_form
@@ -21,6 +20,7 @@ module Decidim
       # Broadcasts :ok if successful, :invalid otherwise.
       def call
         challenge.with_lock do
+          return broadcast(:invalid) unless can_answer_survey?
           return broadcast(:invalid_form) unless survey_form.valid?
 
           answer_questionnaire
@@ -48,6 +48,10 @@ module Decidim
 
       def questionnaire?
         survey_form.model_name == "Questionnaire"
+      end
+
+      def can_answer_survey?
+        !Decidim::Challenges::Survey.where(decidim_user_id: user, decidim_challenge_id: challenge).any?
       end
     end
   end

--- a/app/commands/decidim/challenges/survey_challenge.rb
+++ b/app/commands/decidim/challenges/survey_challenge.rb
@@ -10,6 +10,7 @@ module Decidim
       # user - The user answering the survey.
       # survey_form - A form object with params; can be a questionnaire.
       def initialize(challenge, user, survey_form)
+        super()
         @challenge = challenge
         @user = user
         @survey_form = survey_form
@@ -51,7 +52,7 @@ module Decidim
       end
 
       def can_answer_survey?
-        !Decidim::Challenges::Survey.where(decidim_user_id: user, decidim_challenge_id: challenge).any?
+        Decidim::Challenges::Survey.where(decidim_user_id: user, decidim_challenge_id: challenge).none?
       end
     end
   end

--- a/spec/commands/decidim/challenges/survey_challenge_spec.rb
+++ b/spec/commands/decidim/challenges/survey_challenge_spec.rb
@@ -58,5 +58,15 @@ module Decidim::Challenges
         end
       end
     end
+
+    context "when the user has already answered survey" do
+      before do
+        create(:survey, challenge: challenge, user: user)
+      end
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
   end
 end


### PR DESCRIPTION
### **Bug:**

When the survey is answered in preview mode and the questions are edited, you can answer it again but it breaks when submitting the form.

![preview-full-image](https://user-images.githubusercontent.com/75725233/141114899-6a3c325f-2d2f-4c5e-b899-5bfa9cf17ccf.png)

###  **Fix:**
An error message has been added as it happens in meetings.

This is the normal behaviour of challenges. If you have answered a survey you cannot delete your answer and answer it again. In the preview mode, the answer is saved and even if you change the questions you cannot answer it. This also happens in meetings but there is the option to unsubscribe from the meeting.


![Captura de pantalla de 2021-11-10 12-18-59](https://user-images.githubusercontent.com/75725233/141114334-e3bbfeb0-3a43-4c37-b110-b9714fbe71a6.png)
