### PR TITLE
Add author_type to surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.7.4 (PATCH)
+- Add author_type as Decidim requires Surveys to have that column.
+
 ## Version 0.7.3 (PATCH)
 - Add migration to solve bug in surveys
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-challenges (0.7.3)
+    decidim-challenges (0.7.4)
       decidim-core (~> 0.29)
 
 GEM

--- a/app/models/decidim/challenges/survey.rb
+++ b/app/models/decidim/challenges/survey.rb
@@ -7,9 +7,12 @@ module Decidim
       include Decidim::DownloadYourData
 
       belongs_to :challenge, foreign_key: "decidim_challenge_id", class_name: "Decidim::Challenges::Challenge"
-      belongs_to :author, foreign_key: "decidim_author_id", class_name: "Decidim::User"
+      belongs_to :author,
+                 polymorphic: true,
+                 foreign_key: "decidim_author_id",
+                 foreign_type: "decidim_author_type"
 
-      validates :decidim_author_id, uniqueness: { scope: :decidim_challenge_id }
+      validates :decidim_author_id, uniqueness: { scope: [:decidim_challenge_id, :decidim_author_type] }
 
       def self.export_serializer
         Decidim::Challenges::DownloadYourDataSurveySerializer

--- a/db/migrate/20260116075427_add_author_type_to_challenges_surveys.rb
+++ b/db/migrate/20260116075427_add_author_type_to_challenges_surveys.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class AddAuthorTypeToChallengesSurveys < ActiveRecord::Migration[6.1]
+  class ChallengeSurvey < ApplicationRecord
+    self.table_name = "decidim_challenges_surveys"
+  end
+
+  def up
+    add_column :decidim_challenges_surveys, :decidim_author_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_challenges_surveys
+          SET decidim_author_type = 'Decidim::UserBaseEntity'
+        SQL
+      end
+    end
+
+    remove_index :decidim_challenges_surveys, name: "decidim_challenges_surveys_author_challenge_unique", if_exists: true
+
+    add_index :decidim_challenges_surveys,
+              [:decidim_author_id, :decidim_author_type, :decidim_challenge_id],
+              unique: true,
+              name: "decidim_challenges_surveys_author_challenge_unique"
+    change_column_null :decidim_challenges_surveys, :decidim_author_id, false
+    change_column_null :decidim_challenges_surveys, :decidim_author_type, false
+  end
+
+  def down
+    remove_index :decidim_challenges_surveys, name: "decidim_challenges_surveys_author_challenge_unique", if_exists: true
+
+    remove_column :decidim_challenges_surveys, :decidim_author_type
+
+    add_index :decidim_challenges_surveys,
+              [:decidim_author_id, :decidim_challenge_id],
+              unique: true,
+              name: "decidim_challenges_surveys_author_challenge_unique"
+  end
+end

--- a/decidim-challenges.gemspec
+++ b/decidim-challenges.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = ["199462+tramuntanal@users.noreply.github.com"]
   s.license = "AGPL-3.0"
   s.homepage = "https://github.com/decidim/decidim-module-challenges"
-  s.required_ruby_version = ">= 3.2.9"
+  s.required_ruby_version = ">= 3.2.2"
 
   s.name = "decidim-challenges"
   s.summary = "A decidim challenges module"

--- a/lib/decidim/challenges/version.rb
+++ b/lib/decidim/challenges/version.rb
@@ -4,7 +4,7 @@ module Decidim
   # This holds the decidim-meetings version.
   module Challenges
     def self.version
-      "0.7.3"
+      "0.7.4"
     end
 
     def self.decidim_version


### PR DESCRIPTION
In order to avoid: `PG::UndefinedColumn: ERROR:  column decidim_challenges_surveys.decidim_author_type does not exist` in 

```
decidim-core/lib/decidim/exporters/csv.rb:50:in `map'
decidim-core/lib/decidim/exporters/csv.rb:50:in `processed_collection'
decidim-core/lib/decidim/exporters/csv.rb:28:in `headers'
decidim-core/lib/decidim/exporters/csv.rb:19:in `export'
decidim-core/app/services/decidim/download_your_data_exporter.rb:46:in `block in data_and_attachments_for_user'
decidim-core/app/services/decidim/download_your_data_exporter.rb:44:in `each'
decidim-core/app/services/decidim/download_your_data_exporter.rb:44:in `data_and_attachments_for_user'
decidim-core/app/services/decidim/download_your_data_exporter.rb:29:in `export'
decidim-core/app/jobs/decidim/download_your_data_export_job.rb:22:in `generate_zip_file'
decidim-core/app/jobs/decidim/download_your_data_export_job.rb:12:in `perform'
```